### PR TITLE
Updated mapView's promise method: 'then' to 'when'

### DIFF
--- a/src/js/components/MapView.js
+++ b/src/js/components/MapView.js
@@ -30,7 +30,7 @@ export default class Map extends Component {
       ...VIEW_OPTIONS
     });
 
-    promise.then(view => {
+    promise.when(view => {
       this.setState({
         view: view
       });


### PR DESCRIPTION
Using the MapView's new [.when](https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#when) method over the now-deprecated [.then](https://developers.arcgis.com/javascript/latest/guide/release-notes/4.6/index.html) promise per our update to version 4.9